### PR TITLE
🩹 Fixed logic error on saving output to csv

### DIFF
--- a/src/gh_stats/cli.py
+++ b/src/gh_stats/cli.py
@@ -107,7 +107,7 @@ def main(repos, org, user, output_file, auth_token):
 
         if file_path.suffix == ".csv":
             print("Creating CSV")
-            with open("data.csv", "w", newline="") as file:
+            with open(file_path, "w", newline="") as file:
                 writer = csv.DictWriter(
                     file,
                     fieldnames=[


### PR DESCRIPTION
A hard-coded value for the `csv` output file name was accidentally left in when refactoring from P.O.C. stage. Now correctly uses the CLI arg as `filename`. 